### PR TITLE
adds bug fixes: include paths, irq unlock edge case, and sys init function

### DIFF
--- a/include/pubsub/pubsub.h
+++ b/include/pubsub/pubsub.h
@@ -10,9 +10,9 @@
 
 #include <stdbool.h>
 
-#include <sys/slist.h>
-#include <zephyr.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/slist.h>
+#include <zephyr/init.h>
 
 #define MAX_CHANNELS 4
 

--- a/include/pubsub/pubsub.h
+++ b/include/pubsub/pubsub.h
@@ -140,10 +140,8 @@ int pubsub_poll(struct pubsub_subscriber_s *subscriber, k_timeout_t timeout);
 #define PUBSUB_TOPIC_DEFINE(topic_name, topic_msg_size)			\
 	struct pubsub_topic_s topic_name;  							\
 																\
-	static int pubsub_topic_init_##topic_name(const struct device *dev)		\
+	static int pubsub_topic_init_##topic_name(void)		\
 	{ 															\
-		ARG_UNUSED(dev); 										\
-																\
 		pubsub_topic_init(&topic_name, topic_msg_size); 		\
 		return 0; 												\
 	} 															\
@@ -165,11 +163,9 @@ int pubsub_poll(struct pubsub_subscriber_s *subscriber, k_timeout_t timeout);
 #define PUBSUB_SUBSCRIBER_DEFINE(topic_name, subscriber_name, channel) 	\
 	static struct pubsub_subscriber_s subscriber_name; 				\
 																\
-	static int pubsub_sub_init_##subscriber_name(const struct device *dev) { \
-		ARG_UNUSED(dev); 										\
-																\
+	static int pubsub_sub_init_##subscriber_name(void)                                                              \
+        {                                                                                                               \
 		pubsub_subscriber_register(&topic_name, &subscriber_name, channel); \
-																\
 		return 0; 												\
 	} 															\
 																\

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -69,7 +69,11 @@ void *pubsub_get(struct pubsub_subscriber_s *subscriber)
 {
 	int key = irq_lock();
 
-	if (!subscriber->topic || !(subscriber->topic->init)) return NULL;
+	if (!subscriber->topic || !(subscriber->topic->init)) {
+            irq_unlock(key);
+            return NULL;
+        }
+
 	k_sem_reset(&(subscriber->updated));
 	void *ptr = subscriber->topic->message[subscriber->channel];
 
@@ -82,7 +86,10 @@ void pubsub_copy(struct pubsub_subscriber_s *subscriber, void *msg)
 {
 	int key = irq_lock();
 
-	if (!subscriber->topic || !(subscriber->topic->init)) return;
+	if (!subscriber->topic || !(subscriber->topic->init)) {
+            irq_unlock(key);
+            return;
+        }
 
 	k_sem_reset(&(subscriber->updated));
 	void *ptr = subscriber->topic->message[subscriber->channel];

--- a/src/pubsub.c
+++ b/src/pubsub.c
@@ -1,9 +1,6 @@
 #include <string.h>
 #include <stdbool.h>
 
-#include <sys/slist.h>
-#include <zephyr.h>
-
 #include <pubsub/pubsub.h>
 
 void pubsub_subscriber_notify(struct pubsub_subscriber_s *subscriber);


### PR DESCRIPTION
- Updates include paths to have the necessary `zephyr/` prefix
- Prevents system freeze when uninitialized subscribers are passed to `pubsub_copy` and `pubsub_get` by unlocking IRQs before returning
- Changes the supplied init function to `SYS_INIT` to match the updated signature of `int (*sys)(void)`